### PR TITLE
fix: inaccurate project title bug

### DIFF
--- a/app/views/applicants/index.html.erb
+++ b/app/views/applicants/index.html.erb
@@ -19,7 +19,7 @@
   <% @applicants.each do |applicant| %>
     <tr>
       <td><%= applicant.name %></td>
-      <td><%= applicant.project_title %></td>
+      <td><%= applicant.project.title %></td>
       <td><%= applicant.status.titleize %></td>
       <td><%= link_to "Show this applicant", applicant %></td>
     </tr>


### PR DESCRIPTION
Changes Made:
- Fixed a typo that was resulting in the incorrect Project Name being displayed

Tests Conducted:
- This was a frontend bug, and the correct project name is now being displayed on the Applicants page

How do we prevent this bug in the future?
a) Install a linter, like [erb-lint](https://github.com/Shopify/erb-lint) on the development device, as that will tell the developer(s) when typos like the one fixed occur during development and in code review
- To go a step further with the linter, you can implement the linter as a step in your CI/CD process. By making a linter test to ensure that code in a pull request to the main/production branch is free of typos (alongside other lint checks), buggy code like this would not be deployed to production. The CI/CD pipeline would fail, leaving us with the last stable version until one that passes CI/CD tests is pushed and approved