### PR TITLE
feat: status list with comments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.9-aarch64-linux)
       racc (~> 1.4)
+    nokogiri (1.13.9-x86_64-darwin)
+      racc (~> 1.4)
     parallel (1.22.1)
     parser (3.1.3.0)
       ast (~> 2.4.1)
@@ -192,6 +194,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.5.4-aarch64-linux)
+    sqlite3 (1.5.4-x86_64-darwin)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
     thor (1.2.1)
@@ -215,6 +218,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  x86_64-darwin-21
 
 DEPENDENCIES
   bootsnap

--- a/app/controllers/applicants_controller.rb
+++ b/app/controllers/applicants_controller.rb
@@ -23,6 +23,7 @@ class ApplicantsController < ApplicationController
   # POST /applicants
   def create
     @applicant = Applicant.new(applicant_params)
+    @status = Status.create(status_type: 'applied', comment: 'New applicant', applicant: @applicant)
 
     if @applicant.save
       redirect_to @applicant, notice: 'Applicant was successfully created.'
@@ -55,6 +56,6 @@ class ApplicantsController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def applicant_params
-    params.require(:applicant).permit(:name, :overview, :funding, :project_id, :status)
+    params.require(:applicant).permit(:name, :overview, :funding, :project_id, statuses_attributes: [:status_type, :comment])
   end
 end

--- a/app/models/applicant.rb
+++ b/app/models/applicant.rb
@@ -10,7 +10,13 @@ class Applicant < ApplicationRecord
 
   belongs_to :project
 
-  enum status: { applied: 0, initial_review: 1, more_information_required: 2, declined: 3, approved: 4 }
+  has_many :statuses, dependent: :destroy
+
+  accepts_nested_attributes_for :statuses, reject_if: :all_blank
+
+  def latest_status
+    statuses.order(id: :desc).first.status_type
+  end
 
   def project_title
     'Project'

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -1,0 +1,5 @@
+class Status < ApplicationRecord
+  validates :comment, presence: true
+  enum status_type: { applied: 0, initial_review: 1, more_information_required: 2, declined: 3, approved: 4 }
+  belongs_to :applicant
+end

--- a/app/views/applicants/_applicant.html.erb
+++ b/app/views/applicants/_applicant.html.erb
@@ -20,8 +20,26 @@
   </p>
 
   <p>
-    <strong>Status:</strong>
-    <%= applicant.status.titleize %>
+    <strong>Status Updates:</strong>
   </p>
+
+  <table id="applicants">
+    <thead>
+      <tr>
+        <th>Date</th>
+        <th>Status</th>
+        <th>Comment</th>
+      </tr>
+    </thead>
+    <tbody>
+    <% applicant.statuses.each do |status| %>
+      <tr>
+        <td><%= status.created_at %></td>
+        <td><%= status.status_type.titleize %></td>
+        <td><%= status.comment %></td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
 
 </div>

--- a/app/views/applicants/_form.html.erb
+++ b/app/views/applicants/_form.html.erb
@@ -33,12 +33,16 @@
 
   <% unless applicant.new_record? %>
     <div>
-      <%= form.label :status, style: "display: block" %>
-      <%=
-        form.select :status, options_for_select(
-          Applicant.statuses.map {|key, value| [key.titleize, Applicant.statuses.key(value)]}, applicant.status
-        )
-      %>
+      <%= form.fields_for :statuses, @applicant.statuses.build do |status_form| %> 
+        <%= status_form.label :status, style: "display: block" %>
+        <%=
+          status_form.select :status_type, options_for_select(
+            Status.status_types.map { |k, v| [k.titleize, Status.status_types.key(v)] }, applicant.latest_status || 0
+          )
+        %>
+        <%= status_form.label :comment, style: "display: block" %>
+        <%= status_form.text_field :comment %>
+      <% end %>
     </div>
   <% end %>
 

--- a/app/views/applicants/index.html.erb
+++ b/app/views/applicants/index.html.erb
@@ -20,7 +20,7 @@
     <tr>
       <td><%= applicant.name %></td>
       <td><%= applicant.project_title %></td>
-      <td><%= applicant.status.titleize %></td>
+      <td><%= applicant.latest_status.titleize %></td>
       <td><%= link_to "Show this applicant", applicant %></td>
     </tr>
   <% end %>

--- a/app/views/payments/index.html.erb
+++ b/app/views/payments/index.html.erb
@@ -33,7 +33,7 @@
             project = Project.find_by(title: project)
             applicants = Applicant.all.select do |applicant|
               if applicant.project.title == project.title &&
-                 applicant.status == 'approved'
+                 applicant.latest_status == 'approved'
                 true
               else
                 false

--- a/db/migrate/20221214122530_create_statuses.rb
+++ b/db/migrate/20221214122530_create_statuses.rb
@@ -1,0 +1,11 @@
+class CreateStatuses < ActiveRecord::Migration[7.0]
+  def change
+    create_table :statuses do |t|
+      t.integer :status_type
+      t.text :comment
+      t.references :applicant, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20221214122608_move_status_to_status_table.rb
+++ b/db/migrate/20221214122608_move_status_to_status_table.rb
@@ -1,0 +1,8 @@
+class MoveStatusToStatusTable < ActiveRecord::Migration[7.0]
+  def change
+    Applicant.all.each do |applicant|
+      applicant.statuses.create(status_type: applicant.status, comment: "N/A: Status made before commenting enabled")
+      applicant.save!
+    end
+  end
+end

--- a/db/migrate/20221214123000_remove_status_from_applicants.rb
+++ b/db/migrate/20221214123000_remove_status_from_applicants.rb
@@ -1,0 +1,5 @@
+class RemoveStatusFromApplicants < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :applicants, :status, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_02_112308) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_14_123000) do
   create_table "applicants", force: :cascade do |t|
     t.string "name"
     t.text "overview"
     t.integer "funding"
     t.integer "project_id", null: false
-    t.integer "status"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name"], name: "index_applicants_on_name", unique: true
@@ -41,6 +40,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_02_112308) do
     t.index ["title"], name: "index_projects_on_title", unique: true
   end
 
+  create_table "statuses", force: :cascade do |t|
+    t.integer "status_type"
+    t.text "comment"
+    t.integer "applicant_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["applicant_id"], name: "index_statuses_on_applicant_id"
+  end
+
   add_foreign_key "applicants", "projects"
   add_foreign_key "projects", "funds"
+  add_foreign_key "statuses", "applicants"
 end

--- a/spec/models/status_spec.rb
+++ b/spec/models/status_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Status, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
Changes Made:
- Created a new table for statuses, so we can have many statuses for each applicant, and each status can have its own comment
- Adjusted frontend logic to: 
  - Display historical statuses on applicant page
  - Display the latest status on the Applicants index page
  - Use the latest status when for conditional rendering on the payments page

Database migrations:
- Created table for statuses (`belongs_to: applicant; applicant has_many statuses`)
- Copied all existing statuses to statuses table, with comment denoting the existing status was made before commenting was enabled
- Dropped the status column in applicants

Tests Conducted:
1. Editing a status -> this resulted in a new status entry, not editing the old one
2. Creating a new applicant -> this created a new applicant the initial status "Applied" with comment "New applicant"
3. Loading payments page -> rendered as normal